### PR TITLE
Tell Keplr about CW20

### DIFF
--- a/src/ledgers/KeplrWallet.ts
+++ b/src/ledgers/KeplrWallet.ts
@@ -115,6 +115,9 @@ export class KeplrWallet extends Ledger {
                     average: Number(this.keplrWalletConfig.GAS_PRICE) * 2,
                     high: Number(this.keplrWalletConfig.GAS_PRICE) * 4,
                 },
+                features: [
+                    "cosmwasm"
+                ],
             });
         } catch (ex) {
             console.log(ex);


### PR DESCRIPTION
Keplr adds an "Add Token" option, supporting CW20 contracts, to its menu for a chain which says it supports CosmWasm.

This change adds "cosmwasm" to the features array of the chain specification sent to Keplr, so that CW20 tokens on our network can be added.